### PR TITLE
Store docker layers to Travis cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,23 @@ env:
     - DOCKER_REPOSITORY=mozorg/lumbergh
     - DOCKER_EMAIL="foo@example.com"
     - DOCKER_USERNAME="mozjenkins"
+    - DOCKER_CACHE_FILE=/home/travis/docker/cache.tar.gz
+
     # Django
     - DEBUG=False
     - ALLOWED_HOSTS=*
     - SECRET_KEY=foo
     - DATABASE_URL=mysql://root@db/careers
     - DISABLE_SSL=True
+cache:
+  directories:
+    - /home/travis/docker/
 before_install:
   - docker --version
   - echo "ENV GIT_SHA ${TRAVIS_COMMIT}" >> Dockerfile
+  - if [ -f ${DOCKER_CACHE_FILE} ]; then gunzip -c ${DOCKER_CACHE_FILE} | docker load; fi
 install:
   # Take advantage of docker caching by pulling previously built images.
-  - docker pull ${DOCKER_REPOSITORY}:last_successful_build || true
-  - docker pull ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} || true
   - docker build -t ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} --pull=true .
 before_script:
   - env > .env
@@ -41,6 +45,8 @@ script:
   # Wait database to initialize.
   - docker run --link mariadb:db -e CHECK_PORT=3306 -e CHECK_HOST=db giorgos/takis
   - docker run --env-file .env --link mariadb:db ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} coverage run ./manage.py test
+  # Save built images to Travis cache directory
+  - if [[ ${TRAVIS_BRANCH} == "master" ]]; then docker save $(docker history -q ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} | grep -v '<missing>') | gzip > ${DOCKER_CACHE_FILE}; fi
 after_success:
   - sudo docker cp `docker ps -a -q | head -n 1`:/app /
   - sudo chown travis /app

--- a/bin/deploy-travis.sh
+++ b/bin/deploy-travis.sh
@@ -7,8 +7,6 @@ NRAPP=$3
 
 docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 docker push ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT}
-docker tag ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} ${DOCKER_REPOSITORY}:last_successful_build
-docker push ${DOCKER_REPOSITORY}:last_successful_build
 
 # Install deis client
 curl -sSL http://deis.io/deis-cli/install.sh | sh


### PR DESCRIPTION
Since docker 1.10 and content addressable storage we need to have the
whole chain of layers used to build an image to take advantage of
caching.

Use a specially crafted `docker save` command to save all layers
explicitly and store it in a Travis cached directory. Before each build
load the cache from the same directory.

See also https://github.com/docker/docker/issues/20316