### PR TITLE
[fix bug 1331277] Always set window.ga

### DIFF
--- a/careers/base/static/js/ga_event-tracking.js
+++ b/careers/base/static/js/ga_event-tracking.js
@@ -4,6 +4,9 @@
 ;(function($) {
     'use strict';
 
+    var noopfn = function() {};
+    window.ga = window.ga || noopfn;
+
     var $root = $(':root');
     function trackClick(selector, trackEventArgs) {
         trackEventArgs.unshift('careersSnippetGA.send', 'event');


### PR DESCRIPTION
An adblock filter could possibly block downloading of ga.js and thus window.ga
will remain undefined. This brakes listings filtering and a couple of other
functions.

This patch checks if window.ga is defined and if not defines it as a noop
function.